### PR TITLE
Add functionality for data-test attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ A control component - provides control markup and behaviour.
 - error - An error displayed to the user
 - valid - Whether the control is valid
 - validated - Whether the user has interacted and left the field
+- data-test - The value to use for the data-test attribute on the control. 
+Each child will get a data-test attribute if it is specified. 
+Helpful for attaching browser testing frameworks to the DOM. *(optional)*
 
 ### Text
 

--- a/example/index.js
+++ b/example/index.js
@@ -62,6 +62,10 @@ ReactDOM.render(
         <Form.CheckboxGroup options={{dental: 'Dental', physio: 'Physio', optical: "Optical", chiro: "Chiro", massage: "Massage"}}/>
       </Form.Control>
 
+      <Form.Control valid validated name="testattr" label="So you want to browser test your web app?" data-test="blah">
+        <Form.CheckboxGroup options={{dental: 'Dental', physio: 'Physio', optical: "Optical", chiro: "Chiro", massage: "Massage"}}/>
+      </Form.Control>
+
       <Form.Button label="Submit" />
 
     </Form>

--- a/lib/Control.jsx
+++ b/lib/Control.jsx
@@ -12,7 +12,9 @@ export default class Control extends React.Component {
   render() {
 
     const {label, help, error, valid, validated, children, ...otherProps} = this.props;
-
+    const dataTestAttributeValue = this.props['data-test'];
+    otherProps['data-test'] = dataTestAttributeValue ? 'input' : null; // Value to be passed to children
+    
     const controlClasses = classNames('control', {
       [`control--${this.props.name}`]: this.props.name,
       'control--valid': validated && valid,
@@ -31,14 +33,14 @@ export default class Control extends React.Component {
     });
 
     return (
-      <div className={controlClasses}>
+      <div className={controlClasses} data-test={dataTestAttributeValue ? `${dataTestAttributeValue}-control` : null}>
 
-        <label className="control__label label">
+        <label className="control__label label" data-test={dataTestAttributeValue ? 'label' : null}>
           {label}
         </label>
 
         {help
-        && <span className="control__help">{help}</span>
+        && <span className="control__help" data-test={dataTestAttributeValue ? 'help' : null}>{help}</span>
         }
 
         <div className={controlInputClasses}>
@@ -48,7 +50,7 @@ export default class Control extends React.Component {
           }
 
           {validated
-          && <i className={controlAlertClasses}></i>
+          && <i className={controlAlertClasses} data-test={dataTestAttributeValue ? 'alert' : null}></i>
           }
 
         </div>
@@ -60,8 +62,8 @@ export default class Control extends React.Component {
         >
           {error
           && (
-            <div className="control__message">
-              <p className="control__message-text">{error}</p>
+            <div className="control__message" data-test={dataTestAttributeValue ? 'message' : null}>
+              <p className="control__message-text" data-test={dataTestAttributeValue ? 'message-text' : null}>{error}</p>
             </div>
           )
           }

--- a/test/Control.jsx
+++ b/test/Control.jsx
@@ -93,7 +93,29 @@ describe('Control', () => {
         expect($(element).hasClass('control--invalid')).to.be.true;
     
       });
-  
+      
+      it('should have data-test attribute when data-test attribute is present', () => {
+        const attrValue = 'test-attr';
+        const element = render(
+          <Control name="name" validated data-test={attrValue}>
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).hasProp('data-test', `${attrValue}-control`)).to.be.true;
+      });
+      
+      it('should have data-test attribute set to null when data-test attribute is not present', () => {
+        
+        const element = render(
+          <Control name="name">
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).hasProp('data-test'), null).to.be.true;
+      });
+      
     });
 
     describe('=> control__label', () => {
@@ -109,7 +131,29 @@ describe('Control', () => {
         expect($(element).find('.control__label').hasText('First name')).to.be.true;
 
       });
-
+      
+      it('should have data-test attribute when data-test attribute is present', () => {
+        const attrValue = 'test-attr';
+        const element = render(
+          <Control name="name" validated data-test={attrValue}>
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__label').hasProp('data-test', 'label')).to.be.true;
+      });
+      
+      it('should have data-test attribute set to null when data-test attribute is not present', () => {
+        
+        const element = render(
+          <Control name="name">
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__label').hasProp('data-test'), null).to.be.true;
+      });
+      
     });
 
     describe('=> control__help', () => {
@@ -136,6 +180,28 @@ describe('Control', () => {
 
         expect($(element).find('.control__help').hasText('Just your first name')).to.be.true;
 
+      });
+      
+      it('should have data-test attribute when data-test attribute is present', () => {
+        const attrValue = 'test-attr';
+        const element = render(
+          <Control name="name" help="Help, this control is need of browser testing!" validated data-test={attrValue}>
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__help').hasProp('data-test', 'help')).to.be.true;
+      });
+      
+      it('should have data-test attribute set to null when data-test attribute is not present', () => {
+        
+        const element = render(
+          <Control name="name" help="Help, this control is need of browser testing!">
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__help').hasProp('data-test'), null).to.be.true;
       });
 
     });
@@ -188,6 +254,28 @@ describe('Control', () => {
 
         expect($(element).find('.control__input').hasClass('control__input--shrink')).to.be.true;
 
+      });
+      
+      it('should have data-test attribute when data-test attribute is present', () => {
+        const attrValue = 'test-attr';
+        const element = render(
+          <Control name="name" validated data-test={attrValue}>
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('input').hasProp('data-test', 'input')).to.be.true;
+      });
+      
+      it('should have data-test attribute set to null when data-test attribute is not present', () => {
+        
+        const element = render(
+          <Control name="name">
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('input').hasProp('data-test', null)).to.be.true;
       });
 
     });
@@ -277,7 +365,29 @@ describe('Control', () => {
         expect($(element).find('.control__alert').hasClass('control__alert--checkbox')).to.be.true;
 
       });
-
+      
+      it('should have data-test attribute when data-test attribute is present', () => {
+        const attrValue = 'test-attr';
+        const element = render(
+          <Control name="name" validated data-test={attrValue}>
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__alert').hasProp('data-test', 'alert')).to.be.true;
+      });
+      
+      it('should have data-test attribute set to null when data-test attribute is not present', () => {
+        
+        const element = render(
+          <Control name="name" validated>
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__alert').hasProp('data-test', null)).to.be.true;
+      });
+      
     });
 
     describe('=> control__message', () => {
@@ -310,6 +420,30 @@ describe('Control', () => {
 
         expect($(element).find('.control__message').hasText('Oh!')).to.be.true;
 
+      });
+
+      it('should have data-test attribute when data-test attribute is present', () => {
+        const attrValue = 'test-attr';
+        const element = render(
+          <Control name="name" data-test={attrValue} error="The browser tests are broken!">
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__message').hasProp('data-test', 'message')).to.be.true;
+        expect($(element).find('.control__message-text').hasProp('data-test', 'message-text')).to.be.true;
+      });
+      
+      it('should have data-test attribute set to null when data-test attribute is not present', () => {
+        
+        const element = render(
+          <Control name="name" error="The browser tests are broken!">
+            <input/>
+          </Control>
+        ).element;
+        
+        expect($(element).find('.control__message').hasProp('data-test', null)).to.be.true;
+        expect($(element).find('.control__message-text').hasProp('data-test', null)).to.be.true;
       });
 
     });


### PR DESCRIPTION
Adds functionality for adding data-test attributes to controls.
Specifying data-test='first-name' will populate the control with a data-test attribute with a value of 'first-name-control'. Each child element then gets a data-test attribute with a value corresponding to the elements purpose ie alert, message etc.

Makes it easier for browser testing frameworks to attach to the DOM in a way that is decoupled from the element classes.
